### PR TITLE
Add support for testing Keycloak extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,18 +110,19 @@ See also [`KeycloakContainerHttpsTest.shouldStartKeycloakWithCustomTlsCertAndKey
 
 The method `getAuthServerUrl()` will also return the HTTPS url.
 
-### Test Custom Extensions
+### Testing Custom Extensions
 
-To ease extension testing, you can tell the Keycloak Testcontainer to detect extensions from your classpath.
+To ease extension testing, you can tell the Keycloak Testcontainer to detect extensions in a given classpath folder.
+This allows to test extensions directly in the same module without a packaging step.
 
 If you have your Keycloak extension code in the `src/main/java` folder, then the resulting classes will be generated to the `target/classes` folder.
-To test your extensions you just need to tell `KeycloakContainer` to consider extensions from the `classes` folder.
+To test your extensions you just need to tell `KeycloakContainer` to consider extensions from the `target/classes` folder.
 
 Keycloak Testcontainer will then dynamically generate an exploded "jar file" with the extension code that is then picked up by Keycloak.
 
 ```java
 private KeycloakContainer keycloak = new KeycloakContainer()
-    .withExtensionClassesFrom("classes");
+    .withExtensionClassesFrom("target/classes");
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ See also [`KeycloakContainerHttpsTest.shouldStartKeycloakWithCustomTlsCertAndKey
 
 The method `getAuthServerUrl()` will also return the HTTPS url.
 
+### Test Custom Extensions
+
+To ease extension testing, you can tell the Keycloak Testcontainer to detect extensions from your classpath.
+
+If you have your Keycloak extension code in the `src/main/java` folder, then the resulting classes will be generated to the `target/classes` folder.
+To test your extensions you just need to tell `KeycloakContainer` to consider extensions from the `classes` folder.
+
+Keycloak Testcontainer will then dynamically generate an exploded "jar file" with the extension code that is then picked up by Keycloak.
+
+```java
+private KeycloakContainer keycloak = new KeycloakContainer()
+    .withExtensionClassesFrom("classes");
+```
+
 ## Setup
 
 The release versions of this project are available at [Maven Central](https://search.maven.org/artifact/com.github.dasniko/testcontainers-keycloak).

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.dasniko</groupId>
@@ -79,6 +80,27 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>4.1.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>${keycloak.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
@@ -24,6 +24,14 @@ public class KeycloakContainerExtensionTest {
     public static final String MASTER = "master";
     public static final String ADMIN_CLI = "admin-cli";
 
+    @Test
+    public void shouldStartKeycloakWithNonExistingExtensionClassFolder() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .withExtensionClassesFrom("target/does_not_exist")) {
+            keycloak.start();
+        }
+    }
+
     /**
      * Deploys the Keycloak extensions from the test-classes folder into the create Keycloak container.
      *
@@ -33,8 +41,8 @@ public class KeycloakContainerExtensionTest {
     public void shouldDeployExtension() throws Exception {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .withRealmImportFile("test-realm.json")
-            .withExtensionClassesFrom("test-classes") // this would normally be just "classes"
-        ) {
+            // this would normally be just "target/classes"
+            .withExtensionClassesFrom("target/test-classes")) {
             keycloak.start();
 
             Keycloak keycloakClient = Keycloak.getInstance(keycloak.getAuthServerUrl(), MASTER,

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
@@ -1,0 +1,82 @@
+package dasniko.testcontainers.keycloak;
+
+import dasniko.testcontainers.keycloak.extensions.oidcmapper.TestOidcProtocolMapper;
+import org.junit.Test;
+import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+public class KeycloakContainerExtensionTest {
+
+    public static final String MASTER = "master";
+    public static final String ADMIN_CLI = "admin-cli";
+
+    /**
+     * Deploys the Keycloak extensions from the test-classes folder into the create Keycloak container.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void shouldDeployExtension() throws Exception {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .withRealmImportFile("test-realm.json")
+            .withExtensionClassesFrom("test-classes") // this would normally be just "classes"
+        ) {
+            keycloak.start();
+
+            Keycloak keycloakClient = Keycloak.getInstance(keycloak.getAuthServerUrl(), MASTER,
+                keycloak.getAdminUsername(), keycloak.getAdminPassword(), ADMIN_CLI);
+
+            RealmResource realm = keycloakClient.realm(MASTER);
+            ClientRepresentation client = realm.clients().findByClientId(ADMIN_CLI).get(0);
+
+            configureCustomOidcProtocolMapper(realm, client);
+
+            keycloakClient.tokenManager().refreshToken();
+            AccessTokenResponse tokenResponse = keycloakClient.tokenManager().getAccessToken();
+
+            // parse the received access-token
+            TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class);
+            verifier.parse();
+
+            // check for the custom claim
+            AccessToken accessToken = verifier.getToken();
+            String customClaimValue = (String)accessToken.getOtherClaims().get(TestOidcProtocolMapper.CUSTOM_CLAIM_NAME);
+            System.out.printf("Custom Claim name %s=%s", TestOidcProtocolMapper.CUSTOM_CLAIM_NAME, customClaimValue);
+            assertThat(customClaimValue, notNullValue());
+            assertThat(customClaimValue, startsWith("testdata:"));
+        }
+    }
+
+    /**
+     * Configures the {@link TestOidcProtocolMapper} to the given client in the given realm.
+     *
+     * @param realm
+     * @param client
+     */
+    private static void configureCustomOidcProtocolMapper(RealmResource realm, ClientRepresentation client) {
+
+        ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+        mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        mapper.setProtocolMapper(TestOidcProtocolMapper.ID);
+        mapper.setName("test-mapper");
+        Map<String, String> config = new HashMap<>();
+        config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+        mapper.setConfig(config);
+
+        realm.clients().get(client.getId()).getProtocolMappers().createMapper(mapper).close();
+    }
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/oidcmapper/TestOidcProtocolMapper.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/oidcmapper/TestOidcProtocolMapper.java
@@ -1,0 +1,58 @@
+package dasniko.testcontainers.keycloak.extensions.oidcmapper;
+
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestOidcProtocolMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
+
+    public static final String ID = "test-protocol-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+    public static final String CUSTOM_CLAIM_NAME = "testdata";
+
+    static {
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, TestOidcProtocolMapper.class);
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Test Protocol Mapper";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "A test protocol mapper";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+        token.getOtherClaims().put(CUSTOM_CLAIM_NAME, "testdata:" + System.currentTimeMillis());
+    }
+}

--- a/src/test/resources/META-INF/jboss-deployment-structure.xml
+++ b/src/test/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+    <deployment>
+        <!-- a generous collection of dependencies to simplify the development of extensions -->
+        <dependencies>
+            <module name="org.keycloak.keycloak-common" export="true"/>
+            <module name="org.keycloak.keycloak-core" export="true"/>
+            <module name="org.keycloak.keycloak-server-spi" export="true"/>
+            <module name="org.keycloak.keycloak-server-spi-private" export="true"/>
+            <module name="org.apache.httpcomponents" export="true"/>
+            <module name="org.keycloak.keycloak-services" export="true"/>
+            <module name="org.bouncycastle" export="true" />
+            <module name="com.google.guava" export="true" />
+            <module name="org.jboss.logging" export="true" />
+            <module name="org.apache.commons.io" export="true" />
+            <module name="javax.api" export="true"/>
+            <module name="javax.jms.api" export="true"/>
+            <module name="javax.transaction.api" export="true"/>
+            <module name="com.fasterxml.jackson.core.jackson-core" export="true"/>
+            <module name="com.fasterxml.jackson.core.jackson-annotations" export="true"/>
+            <module name="com.fasterxml.jackson.core.jackson-databind" export="true"/>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>

--- a/src/test/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/src/test/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -1,0 +1,1 @@
+dasniko.testcontainers.keycloak.extensions.oidcmapper.TestOidcProtocolMapper


### PR DESCRIPTION
This adds support for testing Keycloak extensions in the current
project that can be found in the project classes folder.

This enables extension testing with keycloak-testcontainers without
having to package the extensions first.

Fixes #13