### PR TITLE
issue #17 - allow jboss user to delete the deployment marker file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <testcontainers.version>1.15.1</testcontainers.version>
-        <keycloak.version>12.0.1</keycloak.version>
+        <keycloak.version>12.0.4</keycloak.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <testcontainers.version>1.15.1</testcontainers.version>
-        <keycloak.version>12.0.4</keycloak.version>
+        <keycloak.version>12.0.1</keycloak.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
By mounting its parent directory instead of just the specific file, then
marking it writeable for others.

I also upgraded it to Keycloak 12.0.4, but I can easilly revert that if
you want.