### PR TITLE
GH-17 Revise handling of exploded wildfly extensions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             <artifactId>keycloak-services</artifactId>
             <version>${keycloak.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionReuseTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionReuseTest.java
@@ -1,0 +1,87 @@
+package dasniko.testcontainers.keycloak;
+
+import dasniko.testcontainers.keycloak.extensions.oidcmapper.TestOidcProtocolMapper;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.ADMIN_CLI;
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.MASTER;
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.TEST_REALM_JSON;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests reusable containers support for {@link KeycloakContainer}.
+ */
+public class KeycloakContainerExtensionReuseTest {
+
+    public static final KeycloakContainer KEYCLOAK = new KeycloakContainer()
+        .withRealmImportFile(TEST_REALM_JSON)
+        // this would normally be just "target/classes"
+        .withExtensionClassesFrom("target/test-classes")
+        // this enables KeycloakContainer reuse across tests
+        .withReuse(true);
+
+    @BeforeClass
+    public static void beforeAll() {
+        KEYCLOAK.start();
+
+        Keycloak keycloakClient = Keycloak.getInstance(KEYCLOAK.getAuthServerUrl(), MASTER,
+            KEYCLOAK.getAdminUsername(), KEYCLOAK.getAdminPassword(), ADMIN_CLI);
+
+        RealmResource realm = keycloakClient.realm(MASTER);
+        ClientRepresentation client = realm.clients().findByClientId(ADMIN_CLI).get(0);
+
+        KeycloakContainerExtensionTest.configureCustomOidcProtocolMapper(realm, client);
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        KEYCLOAK.stop();
+    }
+
+    @Test
+    public void shouldDeployExtensionWithReuse1() throws Exception {
+        simpleOidcProtocolMapperTest();
+    }
+
+    @Test
+    public void shouldDeployExtensionWithReuse2() throws Exception {
+        simpleOidcProtocolMapperTest();
+    }
+
+    @Test
+    public void shouldDeployExtensionWithReuse3() throws Exception {
+        simpleOidcProtocolMapperTest();
+    }
+
+    private void simpleOidcProtocolMapperTest() throws Exception {
+
+        Keycloak keycloakClient = Keycloak.getInstance(KEYCLOAK.getAuthServerUrl(), MASTER,
+            KEYCLOAK.getAdminUsername(), KEYCLOAK.getAdminPassword(), ADMIN_CLI);
+
+        keycloakClient.tokenManager().grantToken();
+
+        keycloakClient.tokenManager().refreshToken();
+        AccessTokenResponse tokenResponse = keycloakClient.tokenManager().getAccessToken();
+
+        // parse the received access-token
+        TokenVerifier<AccessToken> verifier = TokenVerifier.create(tokenResponse.getToken(), AccessToken.class);
+        verifier.parse();
+
+        // check for the custom claim
+        AccessToken accessToken = verifier.getToken();
+        String customClaimValue = (String) accessToken.getOtherClaims().get(TestOidcProtocolMapper.CUSTOM_CLAIM_NAME);
+        System.out.printf("Custom Claim name %s=%s%n", TestOidcProtocolMapper.CUSTOM_CLAIM_NAME, customClaimValue);
+        assertThat(customClaimValue, notNullValue());
+        assertThat(customClaimValue, startsWith("testdata:"));
+    }
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
@@ -15,14 +15,15 @@ import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import java.util.HashMap;
 import java.util.Map;
 
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.ADMIN_CLI;
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.MASTER;
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.TEST_REALM_JSON;
+
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public class KeycloakContainerExtensionTest {
-
-    public static final String MASTER = "master";
-    public static final String ADMIN_CLI = "admin-cli";
 
     @Test
     public void shouldStartKeycloakWithNonExistingExtensionClassFolder() {
@@ -40,7 +41,7 @@ public class KeycloakContainerExtensionTest {
     @Test
     public void shouldDeployExtension() throws Exception {
         try (KeycloakContainer keycloak = new KeycloakContainer()
-            .withRealmImportFile("test-realm.json")
+            .withRealmImportFile(TEST_REALM_JSON)
             // this would normally be just "target/classes"
             .withExtensionClassesFrom("target/test-classes")) {
             keycloak.start();
@@ -63,7 +64,7 @@ public class KeycloakContainerExtensionTest {
             // check for the custom claim
             AccessToken accessToken = verifier.getToken();
             String customClaimValue = (String)accessToken.getOtherClaims().get(TestOidcProtocolMapper.CUSTOM_CLAIM_NAME);
-            System.out.printf("Custom Claim name %s=%s", TestOidcProtocolMapper.CUSTOM_CLAIM_NAME, customClaimValue);
+            System.out.printf("Custom Claim name %s=%s%n", TestOidcProtocolMapper.CUSTOM_CLAIM_NAME, customClaimValue);
             assertThat(customClaimValue, notNullValue());
             assertThat(customClaimValue, startsWith("testdata:"));
         }
@@ -75,7 +76,7 @@ public class KeycloakContainerExtensionTest {
      * @param realm
      * @param client
      */
-    private static void configureCustomOidcProtocolMapper(RealmResource realm, ClientRepresentation client) {
+    static void configureCustomOidcProtocolMapper(RealmResource realm, ClientRepresentation client) {
 
         ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
         mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
@@ -15,6 +15,11 @@ import static org.junit.Assert.assertThat;
  */
 public class KeycloakContainerTest {
 
+    public static final String MASTER = "master";
+    public static final String ADMIN_CLI = "admin-cli";
+
+    public static final String TEST_REALM_JSON = "test-realm.json";
+
     @Test
     public void shouldStartKeycloak() {
         try (KeycloakContainer keycloak = new KeycloakContainer()) {
@@ -24,7 +29,7 @@ public class KeycloakContainerTest {
 
     @Test
     public void shouldImportRealm() {
-        try (KeycloakContainer keycloak = new KeycloakContainer().withRealmImportFile("test-realm.json")) {
+        try (KeycloakContainer keycloak = new KeycloakContainer().withRealmImportFile(TEST_REALM_JSON)) {
             keycloak.start();
 
             String accountService = given().when().get(keycloak.getAuthServerUrl() + "/realms/test")
@@ -61,8 +66,8 @@ public class KeycloakContainerTest {
     private void checkKeycloakContainerInternals(KeycloakContainer keycloak, String username, String password) {
         Keycloak keycloakAdminClient = KeycloakBuilder.builder()
             .serverUrl(keycloak.getAuthServerUrl())
-            .realm("master")
-            .clientId("admin-cli")
+            .realm(MASTER)
+            .clientId(ADMIN_CLI)
             .username(username)
             .password(password)
             .build();

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/oidcmapper/TestOidcProtocolMapper.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/oidcmapper/TestOidcProtocolMapper.java
@@ -1,5 +1,6 @@
 package dasniko.testcontainers.keycloak.extensions.oidcmapper;
 
+import org.jboss.logging.Logger;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
@@ -16,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TestOidcProtocolMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
+
+    private static final Logger LOG = Logger.getLogger(TestOidcProtocolMapper.class);
 
     public static final String ID = "test-protocol-mapper";
 
@@ -53,6 +56,8 @@ public class TestOidcProtocolMapper extends AbstractOIDCProtocolMapper implement
 
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
-        token.getOtherClaims().put(CUSTOM_CLAIM_NAME, "testdata:" + System.currentTimeMillis());
+        String claimValue = "testdata:" + System.currentTimeMillis();
+        LOG.infof("custom claim value: %s", claimValue);
+        token.getOtherClaims().put(CUSTOM_CLAIM_NAME, claimValue);
     }
 }


### PR DESCRIPTION
We now trigger the deployment of exploded extensions folders during container start 
by copying a dynamically generated ".dodeploy" file.

Previously we mounted an external ".dodeploy" file into the container to trigger the exploded jar deployment, which did not work on some operating systems (OSX) when container reuse was used.

- Added test-case for container reuse support
- Excluded slf4j dependency to fix broken container logging

Fixes #17

This supersedes the pull request https://github.com/dasniko/testcontainers-keycloak/pull/18