### PR TITLE
Multiple realm files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use another Keycloak Docker image/version than used in this Testcontainer:
 private KeycloakContainer keycloak = new KeycloakContainer("jboss/keycloak:13.0.1");
 ```
 
-Power up a Keycloak instance with an existing realm JSON config file (from classpath):
+Power up a Keycloak instance with an existing realm JSON config files (from classpath):
 
 ```java
 @Container

--- a/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
@@ -13,9 +13,7 @@ import org.testcontainers.utility.MountableFile;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Niko Köbler, https://www.n-k.de, @dasniko
@@ -44,7 +42,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     private String adminPassword = KEYCLOAK_ADMIN_PASSWORD;
 
     private String dbVendor = DB_VENDOR;
-    private String importFile;
+    private Set<String> importFiles;
     private String tlsCertFilename;
     private String tlsKeyFilename;
     private boolean useTls = false;
@@ -68,6 +66,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public KeycloakContainer(String dockerImageName) {
         super(dockerImageName);
         withExposedPorts(KEYCLOAK_PORT_HTTP, KEYCLOAK_PORT_HTTPS);
+        importFiles = new HashSet<>();
 //        withLogConsumer(new Slf4jLogConsumer(logger()));
     }
 
@@ -97,10 +96,15 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
             withCopyFileToContainer(MountableFile.forClasspathResource(tlsKeyFilename), keyFileInContainer);
         }
 
-        if (importFile != null) {
+        List<String> filesInContainer = new ArrayList<>();
+        for (String importFile : importFiles) {
             String importFileInContainer = "/tmp/" + importFile;
+            filesInContainer.add(importFileInContainer);
             withCopyFileToContainer(MountableFile.forClasspathResource(importFile), importFileInContainer);
-            withEnv("KEYCLOAK_IMPORT", importFileInContainer);
+        }
+
+        if (!importFiles.isEmpty()) {
+            withEnv("KEYCLOAK_IMPORT", String.join(",", filesInContainer));
         }
 
         if (extensionClassLocation != null) {
@@ -202,7 +206,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     }
 
     public KeycloakContainer withRealmImportFile(String importFile) {
-        this.importFile = importFile;
+        this.importFiles.add(importFile);
         return self();
     }
 

--- a/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
@@ -13,7 +13,12 @@ import org.testcontainers.utility.MountableFile;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author Niko Köbler, https://www.n-k.de, @dasniko
@@ -207,6 +212,11 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     public KeycloakContainer withRealmImportFile(String importFile) {
         this.importFiles.add(importFile);
+        return self();
+    }
+
+    public KeycloakContainer withRealmImportFiles(String... files) {
+        Arrays.stream(files).forEach(this::withRealmImportFile);
         return self();
     }
 

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
@@ -63,8 +63,7 @@ public class KeycloakContainerTest {
     @Test
     public void shouldImportMultipleRealms() {
         try (KeycloakContainer keycloak = new KeycloakContainer().
-            withRealmImportFile(TEST_REALM_JSON).
-            withRealmImportFile("another-realm.json")) {
+            withRealmImportFiles(TEST_REALM_JSON, "another-realm.json")) {
             keycloak.start();
 
             String accountService = given().when().get(keycloak.getAuthServerUrl() + "/realms/test")

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
@@ -61,6 +61,27 @@ public class KeycloakContainerTest {
     }
 
     @Test
+    public void shouldImportMultipleRealms() {
+        try (KeycloakContainer keycloak = new KeycloakContainer().
+            withRealmImportFile(TEST_REALM_JSON).
+            withRealmImportFile("another-realm.json")) {
+            keycloak.start();
+
+            String accountService = given().when().get(keycloak.getAuthServerUrl() + "/realms/test")
+                .then().statusCode(200).body("realm", equalTo("test"))
+                .extract().path("account-service");
+
+            given().when().get(accountService).then().statusCode(200);
+
+            accountService = given().when().get(keycloak.getAuthServerUrl() + "/realms/another")
+                .then().statusCode(200).body("realm", equalTo("another"))
+                .extract().path("account-service");
+
+            given().when().get(accountService).then().statusCode(200);
+        }
+    }
+
+    @Test
     public void shouldReturnServerInfo() {
         try (KeycloakContainer keycloak = new KeycloakContainer()) {
             keycloak.start();

--- a/src/test/resources/another-realm.json
+++ b/src/test/resources/another-realm.json
@@ -1,0 +1,4 @@
+{
+    "realm": "another",
+    "enabled": true
+}


### PR DESCRIPTION
Allows to import multiple realms with KeycloakContainer.withRealmImportFile() method.
Unit test included: KeycloakContainerTest.shouldImportMultipleRealms