### PR TITLE
Support testing Keycloak extensions as provider modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ private KeycloakContainer keycloak = new KeycloakContainer()
     .withExtensionClassesFrom("target/classes");
 ```
 
+You may also deploy your extension as a provider module.
+
+```java
+private KeycloakContainer keycloak = new KeycloakContainer()
+    .withProviderClassesFrom("target/classes");
+```
+
 See also [`KeycloakContainerExtensionTest`](./src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java) class.
 
 ## Setup

--- a/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
@@ -39,9 +39,11 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     private static final String DB_VENDOR = "h2";
 
     private static final String DEFAULT_EXTENSION_NAME = "extensions.jar";
+    private static final String DEFAULT_PROVIDERS_NAME = "providers.jar";
 
     // for Keycloak-X this will be /opt/jboss/keycloak/providers
     private static final String DEFAULT_KEYCLOAK_DEPLOYMENTS_LOCATION = "/opt/jboss/keycloak/standalone/deployments";
+    private static final String DEFAULT_KEYCLOAK_PROVIDERS_LOCATION = "/opt/jboss/keycloak/providers";
 
     private String adminUsername = KEYCLOAK_ADMIN_USER;
     private String adminPassword = KEYCLOAK_ADMIN_PASSWORD;
@@ -55,6 +57,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     private Duration startupTimeout = DEFAULT_STARTUP_TIMEOUT;
 
     private String extensionClassLocation;
+    private String providerClassLocation;
 
     private static final Transferable WILDFLY_DEPLOYMENT_TRIGGER_FILE_CONTENT = Transferable.of("true".getBytes(StandardCharsets.UTF_8));
     private final Set<String> wildflyDeploymentTriggerFiles = new HashSet<>();
@@ -115,6 +118,10 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
         if (extensionClassLocation != null) {
             createKeycloakExtensionDeployment(extensionClassLocation);
         }
+
+        if (providerClassLocation != null) {
+            createKeycloakExtensionProvider(providerClassLocation);
+        }
     }
 
     /**
@@ -124,6 +131,15 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
      */
     public void createKeycloakExtensionDeployment(String extensionClassFolder) {
         createKeycloakExtensionDeployment(DEFAULT_KEYCLOAK_DEPLOYMENTS_LOCATION, DEFAULT_EXTENSION_NAME, extensionClassFolder);
+    }
+
+    /**
+     * Maps the provided {@code extensionClassFolder} as an exploded providers.jar to the Keycloak providers folder.
+     *
+     * @param extensionClassFolder a path relative to the current classpath root.
+     */
+    public void createKeycloakExtensionProvider(String extensionClassFolder) {
+        createKeycloakExtensionDeployment(DEFAULT_KEYCLOAK_PROVIDERS_LOCATION, DEFAULT_EXTENSION_NAME, extensionClassFolder);
     }
 
     /**
@@ -249,6 +265,16 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
      */
     public KeycloakContainer withExtensionClassesFrom(String classesLocation) {
         this.extensionClassLocation = classesLocation;
+        return self();
+    }
+
+    /**
+     * Exposes the given classes location as an exploded providers.jar.
+     *
+     * @param classesLocation a classes location relative to the current classpath root.
+     */
+    public KeycloakContainer withProviderClassesFrom(String classesLocation) {
+        this.providerClassLocation = classesLocation;
         return self();
     }
 

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
@@ -18,6 +18,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import static dasniko.testcontainers.keycloak.KeycloakContainerTest.ADMIN_CLI;
 import static dasniko.testcontainers.keycloak.KeycloakContainerTest.MASTER;
@@ -44,10 +45,21 @@ public class KeycloakContainerExtensionTest {
      */
     @Test
     public void shouldDeployExtension() throws Exception {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
-            .withRealmImportFile(TEST_REALM_JSON)
+        shouldDeploy(kc ->
             // this would normally be just "target/classes"
-            .withExtensionClassesFrom("target/test-classes")) {
+            kc.withExtensionClassesFrom("target/test-classes"));
+    }
+
+    @Test
+    public void shouldDeployProvider() throws Exception {
+        shouldDeploy(kc ->
+            // this would normally be just "target/classes"
+            kc.withProviderClassesFrom("target/test-classes"));
+    }
+
+    private void shouldDeploy(Function<KeycloakContainer, KeycloakContainer> configurator) throws Exception {
+        try (KeycloakContainer keycloak = configurator.apply(new KeycloakContainer())
+            .withRealmImportFile(TEST_REALM_JSON)) {
             keycloak.start();
 
             Keycloak keycloakClient = Keycloak.getInstance(keycloak.getAuthServerUrl(), MASTER,
@@ -76,9 +88,22 @@ public class KeycloakContainerExtensionTest {
 
     @Test
     public void shouldDeployExtensionAndCallCustomEndpoint() throws Exception {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
+        shouldDeployAndCallCustomEndpoint(kc ->
+                // this would normally be just "target/classes"
+                kc.withExtensionClassesFrom("target/test-classes")
+            );
+    }
+
+    @Test
+    public void shouldDeployProviderAndCallCustomEndpoint() throws Exception {
+        shouldDeployAndCallCustomEndpoint(kc ->
             // this would normally be just "target/classes"
-            .withExtensionClassesFrom("target/test-classes")) {
+            kc.withExtensionClassesFrom("target/test-classes")
+        );
+    }
+
+    private void shouldDeployAndCallCustomEndpoint(Function<KeycloakContainer, KeycloakContainer> configurator) throws Exception {
+        try (KeycloakContainer keycloak = configurator.apply(new KeycloakContainer())) {
             keycloak.start();
 
             ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
When developing custom SPIs Keycloak does not pick them up when
deploying them as an extension. SPIs can be deployed as provider modules
instead. This commit adds support for testing extensions as provider
modules.

See [this test](https://github.com/sventorben/keycloak-restrict-client-auth/tree/main/src/test/java/de/sventorben/keycloak/authorization/client) as an example.

It makes use of the providers deployment from the Keycloak subsystem:

```shell
$ docker run --rm --entrypoint=cat quay.io/keycloak/keycloak:15.0.2 /opt/jboss/keycloak/standalone/configuration/standalone-ha.xml | grep -A 6 dom
ain:keycloak-server
        <subsystem xmlns="urn:jboss:domain:keycloak-server:1.1">
            <web-context>auth</web-context>
            <providers>
                <provider>
                    classpath:${jboss.home.dir}/providers/*       <!--- THIS -->
                </provider>
            </providers>
```

This is basically the same as adding a module as a provider (see [documentation here](https://github.com/keycloak/keycloak-documentation/blob/15.0.2/server_development/topics/providers.adoc#register-a-provider-using-modules)), but simply adds the jar to the classpath instead of using a module.