### PR TITLE
add option to enable "--auto-build"

### DIFF
--- a/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
@@ -84,6 +84,8 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     private String providerClassLocation;
 
+    private boolean needAutoBuild = false;
+
     /**
      * Create a KeycloakContainer with default image and version tag
      */
@@ -105,7 +107,6 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     @Override
     protected void configure() {
-        boolean needAutoBuild = false;
         List<String> commandParts = new ArrayList<>();
         commandParts.add("start");
         commandParts.add("--http-enabled=true");
@@ -311,6 +312,14 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     public KeycloakContainer withFeaturesDisabled(String... features) {
         this.featuresDisabled = features;
+        return self();
+    }
+
+    /**
+     * Start the keycloak with "--auto-build" option
+     */
+    public KeycloakContainer withAutoBuild() {
+        this.needAutoBuild = true;
         return self();
     }
 


### PR DESCRIPTION
I have a scenario with a custom provider with lib 3rd party libraries in the same package (fat jar).
The jar is copied to the container, but I need to pass "auto-build" option to the keycloak, and this is not supported yet.

```
keycloak = new KeycloakContainer()
    .withCopyFileToContainer(MountableFile.forHostPath('path to fat jar'), "/opt/keycloak/providers/")
    .withRealmImportFile("/test-realm.json");
    .withAutoBuild() // My pull request
    .start();
```