### PR TITLE
Add maven libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ KeycloakContainer keycloak = new KeycloakContainer()
 
 See also [`KeycloakContainerExtensionTest`](./src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java) class.
 
+### Add 3rd party libraries
+
+Inform the canonical name of the local maven dependencies.
+This and all the transients packages will be copy to the provider folder.
+
+```java
+KeycloakContainer keycloak = new KeycloakContainer()
+    .withProviderClassesFrom("target/classes")
+    .withMavenDependencies("groupId:artifactId:version");
+```
+
 ## Setup
 
 The release versions of this project are available at [Maven Central](https://search.maven.org/artifact/com.github.dasniko/testcontainers-keycloak).

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,9 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.version>2.7.0.Final</quarkus.version>
-        <shrinkwrap.verion>1.2.6</shrinkwrap.verion>
+        <shrinkwrap.version>1.2.6</shrinkwrap.version>
+        <shrinkwrap.resolvers.version>2.2.7</shrinkwrap.resolvers.version>
+
         <testcontainers.version>1.16.3</testcontainers.version>
     </properties>
 
@@ -84,13 +86,18 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-            <version>${shrinkwrap.verion}</version>
+            <version>${shrinkwrap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <version>${shrinkwrap.verion}</version>
+            <version>${shrinkwrap.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.jboss.shrinkwrap.resolver</groupId>
+			<artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+			<version>${shrinkwrap.resolvers.version}</version>
+		</dependency>
 
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/KeycloakContainer.java
@@ -296,6 +296,11 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
         return self();
     }
 
+    /**
+     * Copy local maven packages and transitive dependencies to the keycloak provider folder
+     *
+     * @param canonicalForms "groupId:artifactId:version"
+     */
     public KeycloakContainer withMavenDependencies(String... canonicalForms) {
         this.mavenDependencies = canonicalForms;
         return self();


### PR DESCRIPTION
Issue [#58](https://github.com/dasniko/testcontainers-keycloak/issues/58)

Sample:

```java
keycloak = new KeycloakContainer()
    .withProviderClassesFrom("target/classes");
    .withMavenDependencies("org.apache.commons:commons-dbcp2:2.9.0",
				"G:A:");
```
This copy transients dependencies too.