### PR TITLE
Move to datafaker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerExtensionTest.java
@@ -106,7 +106,7 @@ public class KeycloakContainerExtensionTest {
     public void shouldDeployProviderWithDependencyAndCallCustomEndpoint() throws Exception {
         List<File> dependencies = Maven.resolver()
             .loadPomFromFile("./pom.xml")
-            .resolve("com.github.javafaker:javafaker")
+            .resolve("net.datafaker:datafaker")
             .withoutTransitivity().asList(File.class);
 
         try (KeycloakContainer keycloak = new KeycloakContainer()

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/resource/YodaResourceProvider.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/resource/YodaResourceProvider.java
@@ -1,6 +1,6 @@
 package dasniko.testcontainers.keycloak.extensions.resource;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 import javax.ws.rs.GET;


### PR DESCRIPTION
Since [javafaker](https://github.com/DiUS/java-faker) is hardly supported there is a fork of javafaker - [datafaker](https://github.com/datafaker-net/datafaker) which is evolving keeping javafaker APIs.
The PR suggests to move to datafaker