### PR TITLE
Remove quarkus-junit4-mock dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,15 +70,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--
-        Module with some empty JUnit4 classes to allow Testcontainers to run without needing to include JUnit4 on the class path
-        See also https://github.com/testcontainers/testcontainers-java/issues/970 for more details
-        -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit4-mock</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>

--- a/src/main/java/org/junit/rules/TestRule.java
+++ b/src/main/java/org/junit/rules/TestRule.java
@@ -1,0 +1,5 @@
+package org.junit.rules;
+
+@SuppressWarnings("unused")
+public interface TestRule {
+}

--- a/src/main/java/org/junit/runners/model/Statement.java
+++ b/src/main/java/org/junit/runners/model/Statement.java
@@ -1,0 +1,7 @@
+
+
+package org.junit.runners.model;
+
+@SuppressWarnings("unused")
+public interface Statement {
+}


### PR DESCRIPTION
Run integration test with Testcontainers without using JUnit4 dependency.
https://fullstackcode.dev/2022/08/14/using-testcontainers-without-junit4-dependency/