### PR TITLE
Replaced Javafaker with Datafaker and upgrade of several dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,13 +118,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>5.8.2</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -136,13 +136,13 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>5.0.1</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>1.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/resource/YodaResourceProvider.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/resource/YodaResourceProvider.java
@@ -1,6 +1,6 @@
 package dasniko.testcontainers.keycloak.extensions.resource;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 import javax.ws.rs.GET;


### PR DESCRIPTION
Hi there, I'm one of the maintainers of Datafaker, which is an active fork of Javafaker. Javafaker is no longer maintained, and contains several bugs and security issues. I've also upgraded some of the other dependencies to keep the dependencies up to data.