### PR TITLE
Fix default context path

### DIFF
--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -65,7 +65,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
 
     private static final String KEYCLOAK_ADMIN_USER = "admin";
     private static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
-    private static final String KEYCLOAK_CONTEXT_PATH = "/";
+    private static final String KEYCLOAK_CONTEXT_PATH = "";
 
     private static final String DEFAULT_KEYCLOAK_PROVIDERS_NAME = "providers.jar";
     private static final String DEFAULT_KEYCLOAK_PROVIDERS_LOCATION = "/opt/keycloak/providers";


### PR DESCRIPTION
Currently, the default `contextPath`, `KEYCLOAK_CONTEXT_PATH`, is a `/`, which matches the Keycloak documentation.

The URL returned from `getAuthServerUrl()` ends with the `contextPath`:
https://github.com/dasniko/testcontainers-keycloak/blob/8f8bb8471447f3af0816e75e3b906da7106e8197/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java#L392-L395

If the `contextPath` is not modified, then the URL returned from `getAuthServerUrl()` ends with a `/`, which is problematic.

For example, if I were to configure Spring Security OAuth2 Resource Server with the return value from `getAuthServerUrl()`, e.g.
```java
var issuerUri = keycloakContainer.getAuthServerUrl() + "/realms/" + realm;
TestPropertyValues.of(
    "spring.security.oauth2.resourceserver.jwt.issuer-uri", issuerUri)
    .applyTo(configurableApplicationContext)
```

If the `contextPath` is modified, e.g. `/auth`, then the example above works. But if the `contextPath` is not modified, then the example above fails with:

> The Issuer "http://localhost:<port>/realms/realm" provided in the configuration metadata did not match the requested issuer "http://localhost:<port>//realms/realm"

While it is possible to write code that checks if the returned URL ends with a `/`, it is much easier if it was simply changed to an empty String. I don't see anywhere in the code that it would make a difference.