### PR TITLE
Make `withProviderClassesFrom` work with Gradle

### DIFF
--- a/src/test/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainerTest.java
@@ -1,0 +1,63 @@
+package dasniko.testcontainers.keycloak;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
+
+class ExtendableKeycloakContainerTest {
+
+
+    @DisplayName("`resolveExtensionClassLocation` resolves `target/classes`")
+    @Test
+    void resolveExtensionClassLocationResolvesTargetClasses(){
+        final String input = "target/classes";
+        final Path expected = absolute("target/classes");
+
+        resolveAndAssert(input, expected);
+    }
+
+    @DisplayName("`resolveExtensionClassLocation` resolves `target/test-classes`")
+    @Test
+    void resolveExtensionClassLocationResolvesTargetTestClasses(){
+        final String input = "target/test-classes";
+        final Path expected = absolute("target/test-classes");
+
+        resolveAndAssert(input, expected);
+    }
+
+    @DisplayName("`resolveExtensionClassLocation` resolves `build/classes/java/main`")
+    @Test
+    void resolveExtensionClassLocationResolvesBuildClassesMain(){
+        final String input = "build/classes/java/main";
+        final Path expected = absolute("build/classes/java/main");
+
+        resolveAndAssert(input, expected);
+    }
+
+    @DisplayName("`resolveExtensionClassLocation` resolves `build/classes/java/test`")
+    @Test
+    void resolveExtensionClassLocationResolvesBuildClassesTest(){
+        final String input = "build/classes/java/test";
+        final Path expected = absolute("build/classes/java/test");
+
+        resolveAndAssert(input, expected);
+    }
+
+    private static void resolveAndAssert(final String input, final Path expected) {
+        try(final KeycloakContainer keycloakContainer = new KeycloakContainer()){
+            final String resolvedExtensionClassLocation = keycloakContainer.resolveExtensionClassLocation(input);
+            Assertions.assertEquals(expected.toString(), resolvedExtensionClassLocation);
+        }
+    }
+
+    private static Path absolute(final String expected) {
+        return Paths.get(MountableFile.forClasspathResource(".").getResolvedPath())
+                .getParent()
+                .getParent()
+                .resolve(expected)
+                .toAbsolutePath();
+    }
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainerTest.java
@@ -3,48 +3,23 @@ package dasniko.testcontainers.keycloak;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.utility.MountableFile;
 
 class ExtendableKeycloakContainerTest {
 
 
-    @DisplayName("`resolveExtensionClassLocation` resolves `target/classes`")
-    @Test
-    void resolveExtensionClassLocationResolvesTargetClasses(){
-        final String input = "target/classes";
-        final Path expected = absolute("target/classes");
+    @ParameterizedTest
+    @ValueSource(strings = {"target/classes", "target/test-classes", "build/classes/java/main", "build/classes/java/test"})
+    void resolveExtensionClassLocation(final String input){
+
+        final Path expected = absolute(input);
 
         resolveAndAssert(input, expected);
+
     }
 
-    @DisplayName("`resolveExtensionClassLocation` resolves `target/test-classes`")
-    @Test
-    void resolveExtensionClassLocationResolvesTargetTestClasses(){
-        final String input = "target/test-classes";
-        final Path expected = absolute("target/test-classes");
-
-        resolveAndAssert(input, expected);
-    }
-
-    @DisplayName("`resolveExtensionClassLocation` resolves `build/classes/java/main`")
-    @Test
-    void resolveExtensionClassLocationResolvesBuildClassesMain(){
-        final String input = "build/classes/java/main";
-        final Path expected = absolute("build/classes/java/main");
-
-        resolveAndAssert(input, expected);
-    }
-
-    @DisplayName("`resolveExtensionClassLocation` resolves `build/classes/java/test`")
-    @Test
-    void resolveExtensionClassLocationResolvesBuildClassesTest(){
-        final String input = "build/classes/java/test";
-        final Path expected = absolute("build/classes/java/test");
-
-        resolveAndAssert(input, expected);
-    }
 
     private static void resolveAndAssert(final String input, final Path expected) {
         try(final KeycloakContainer keycloakContainer = new KeycloakContainer()){

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/somespi/SomeKeycloakSpi.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/somespi/SomeKeycloakSpi.java
@@ -1,0 +1,25 @@
+package dasniko.testcontainers.keycloak.extensions.somespi;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.keycloak.services.resource.RealmResourceProvider;
+
+public class SomeKeycloakSpi implements RealmResourceProvider {
+
+    @Override
+    public Object getResource() {
+        return this;
+    }
+
+    @Override
+    public void close() {}
+
+    @SuppressWarnings("unused")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        return "Hello world!";
+    }
+
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/extensions/somespi/SomeKeycloakSpiFactory.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/extensions/somespi/SomeKeycloakSpiFactory.java
@@ -1,0 +1,38 @@
+package dasniko.testcontainers.keycloak.extensions.somespi;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+public class SomeKeycloakSpiFactory implements RealmResourceProviderFactory {
+
+    @SuppressWarnings("unused")
+    public static final String ID = "some-keycloak-spi";
+
+    @Override
+    public RealmResourceProvider create(KeycloakSession session) {
+        return new SomeKeycloakSpi();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/src/test/resources/imaginarygradlebuilddir/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
+++ b/src/test/resources/imaginarygradlebuilddir/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
@@ -1,0 +1,1 @@
+dasniko.testcontainers.keycloak.extensions.somespi.SomeKeycloakSpiFactory


### PR DESCRIPTION
This PR addresses a little shortcoming I encountered when trying to use the Keycloak Testcontainer in a Gradle project:

The [`withProviderClassesFrom`-method] takes a relative path as an argument, usually `targets/classes`. The Gradle counterpart of that path is `build/classes/java/main` and it isn't resolved correctly for Gradle projects. 
Moreover, the logic assumes that the `META-INF` directory is located _inside_ the extension classes folder. This is also not true for Gradle projects.

Maven `target` directory structure:
![Maven target directory structure](https://github.com/dasniko/testcontainers-keycloak/assets/30981607/91c2fadc-4706-46ce-a430-085ebc4d2344)

Gradle `build` directory structure:
![Gradle build directory structure](https://github.com/dasniko/testcontainers-keycloak/assets/30981607/0441c300-ad91-4717-b0c8-fef1db4b50af)

The issue is demonstrated in this [example test].

This PR contains a possible fix, in which the classes directory is resolved relative to the current user directory and the `META-INF` directory is sought in the location we suspect it with Gradle, and added, if found.

⚠️ By default, I expect the user working directory (as in the [`user.dir` system property]) to be the project or module directory, both with Maven and with Gradle. I'm not sure though, if there can be custom project setups where this assumption isn't true or where the `user.dir` property is set in an unexpected way. So, this _might_ be a breaking change, after all. But I'm confident that it's going to work for most projects.

Followed [Baeldung] and plenty of Google hits for how to get hold of the current user working directory: System property `user.dir`.

Added a few unit tests for the path resolution functionality. The tests use the old logic to show that, under default conditions, the outcome didn't change for Maven layouts.

 The [example test] that uses the right path succeeds if you use a KC testcontainers library with the fix. 

If you have concerns about breaking the API or anything else, I can rewrite the PR according to your preferences. 

Thanks!

---

**Update**: Changed the original suggestion to an API extension that makes the configuration agnostic to the build tool: Make _multiple_ paths configurable for classes and resources that should be added to the on-the-fly `.jar`-file.


[Baeldung]: https://www.baeldung.com/java-current-directory
[example test]: https://github.com/objecttrouve/keycloak-testcontainers-gradle-issue-example/blob/main/lib/src/test/java/org/objecttrouve/keycloak/testcontainers/issues/gradleworkingdir/SomeKeycloakSpiTest.java
[`user.dir` system property]: https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
[`withProviderClassesFrom`-method]: https://github.com/dasniko/testcontainers-keycloak#testing-custom-extensions