### PR TITLE
change wait strategy to use log output

### DIFF
--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -148,8 +148,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
         }
 
         setWaitStrategy(Wait
-            .forHttp(contextPath)
-            .forPort(KEYCLOAK_PORT_HTTP)
+            .forLogMessage(".*Running the server in development mode\\. DO NOT use this configuration in production.*\\n", 1)
             .withStartupTimeout(startupTimeout)
         );
 
@@ -205,6 +204,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
             withEnv("KC_SPI_THEME_STATIC_MAX_AGE", String.valueOf(2592000));
         }
 
+        commandParts.add("--health-enabled=true");
         commandParts.add("--metrics-enabled=" + metricsEnabled);
 
         if (debugEnabled) {

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,4 +1,4 @@
-junit.jupiter.execution.parallel.enabled = false
-junit.jupiter.execution.parallel.config.fixed.parallelism = 5
+junit.jupiter.execution.parallel.enabled = true
+#junit.jupiter.execution.parallel.config.fixed.parallelism = 5
 junit.jupiter.execution.parallel.mode.default = concurrent
 junit.jupiter.execution.parallel.mode.classes.default = same_thread


### PR DESCRIPTION
Using the health checks (any endpoint of them) or general port availability for a wait strategy is too fast nowadays and this yields in `401` responses when accessing the KC container with the admin client.
So now we're "just" waiting for the log output that the server is started in dev mode, which should be finde.