### PR TITLE
new truststore config

### DIFF
--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -76,13 +76,15 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     private static final String KEYCLOAK_ADMIN_USER = "admin";
     private static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
     private static final String KEYCLOAK_CONTEXT_PATH = "";
+    private static final String KEYCLOAK_HOME_DIR = "/opt/keycloak";
+    private static final String KEYCLOAK_CONF_DIR = KEYCLOAK_HOME_DIR + "/conf";
 
     private static final String DEFAULT_KEYCLOAK_PROVIDERS_NAME = "providers.jar";
-    private static final String DEFAULT_KEYCLOAK_PROVIDERS_LOCATION = "/opt/keycloak/providers";
-    private static final String DEFAULT_REALM_IMPORT_FILES_LOCATION = "/opt/keycloak/data/import/";
+    private static final String DEFAULT_KEYCLOAK_PROVIDERS_LOCATION = KEYCLOAK_HOME_DIR + "/providers";
+    private static final String DEFAULT_REALM_IMPORT_FILES_LOCATION = KEYCLOAK_HOME_DIR + "/data/import/";
 
-    private static final String KEYSTORE_FILE_IN_CONTAINER = "/opt/keycloak/conf/server.keystore";
-    private static final String TRUSTSTORE_FILE_IN_CONTAINER = "/opt/keycloak/conf/server.truststore";
+    private static final String KEYSTORE_FILE_IN_CONTAINER = KEYCLOAK_CONF_DIR + "/server.keystore";
+    private static final String TRUSTSTORE_FILE_IN_CONTAINER = KEYCLOAK_CONF_DIR + "/server.truststore";
 
     private String adminUsername = KEYCLOAK_ADMIN_USER;
     private String adminPassword = KEYCLOAK_ADMIN_PASSWORD;
@@ -161,8 +163,8 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
         withEnv("JAVA_OPTS_KC_HEAP", "-XX:InitialRAMPercentage=%d -XX:MaxRAMPercentage=%d".formatted(initialRamPercentage, maxRamPercentage));
 
         if (useTls && isNotBlank(tlsCertificateFilename)) {
-            String tlsCertFilePath = "/opt/keycloak/conf/tls.crt";
-            String tlsCertKeyFilePath = "/opt/keycloak/conf/tls.key";
+            String tlsCertFilePath = KEYCLOAK_CONF_DIR + "/tls.crt";
+            String tlsCertKeyFilePath = KEYCLOAK_CONF_DIR + "/tls.key";
             withCopyFileToContainer(MountableFile.forClasspathResource(tlsCertificateFilename), tlsCertFilePath);
             withCopyFileToContainer(MountableFile.forClasspathResource(tlsCertificateKeyFilename), tlsCertKeyFilePath);
             withEnv("KC_HTTPS_CERTIFICATE_FILE", tlsCertFilePath);
@@ -176,12 +178,11 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
             withCopyFileToContainer(MountableFile.forClasspathResource(tlsTruststoreFilename), TRUSTSTORE_FILE_IN_CONTAINER);
             withEnv("KC_HTTPS_TRUST_STORE_FILE", TRUSTSTORE_FILE_IN_CONTAINER);
             withEnv("KC_HTTPS_TRUST_STORE_PASSWORD", tlsTruststorePassword);
-            withEnv("KC_HTTPS_CLIENT_AUTH", httpsClientAuth.toString());
         }
         if (isNotEmpty(tlsTrustedCertificateFilenames)) {
             List<String> truststorePaths = new ArrayList<>();
             tlsTrustedCertificateFilenames.forEach(certificateFilename -> {
-                String certPathInContainer = "/opt/keycloak/conf" + (certificateFilename.startsWith("/") ? "" : "/") + certificateFilename;
+                String certPathInContainer = KEYCLOAK_CONF_DIR + (certificateFilename.startsWith("/") ? "" : "/") + certificateFilename;
                 withCopyFileToContainer(MountableFile.forClasspathResource(certificateFilename), certPathInContainer);
                 truststorePaths.add(certPathInContainer);
             });

--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -178,7 +178,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
             withEnv("KC_HTTPS_TRUST_STORE_PASSWORD", tlsTruststorePassword);
             withEnv("KC_HTTPS_CLIENT_AUTH", httpsClientAuth.toString());
         }
-        if (useTls && isNotEmpty(tlsTrustedCertificateFilenames)) {
+        if (isNotEmpty(tlsTrustedCertificateFilenames)) {
             List<String> truststorePaths = new ArrayList<>();
             tlsTrustedCertificateFilenames.forEach(certificateFilename -> {
                 String certPathInContainer = "/opt/keycloak/conf" + (certificateFilename.startsWith("/") ? "" : "/") + certificateFilename;
@@ -186,8 +186,8 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
                 truststorePaths.add(certPathInContainer);
             });
             withEnv("KC_TRUSTSTORE_PATHS", String.join(",", truststorePaths));
-            withEnv("KC_HTTPS_CLIENT_AUTH", httpsClientAuth.toString());
         }
+        withEnv("KC_HTTPS_CLIENT_AUTH", httpsClientAuth.toString());
 
         withEnv("KC_METRICS_ENABLED", Boolean.toString(metricsEnabled));
         withEnv("KC_HEALTH_ENABLED", Boolean.toString(Boolean.TRUE));
@@ -413,7 +413,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     }
 
     /**
-     * @deprecated Will be removed soon! Use {@link #withMutualTls(List, HttpsClientAuth)} instead.
+     * @deprecated Will be removed soon! Use {@link #withTrustedCertificates(List)} and {@link #withHttpsClientAuth(HttpsClientAuth)} instead.
      */
     @Deprecated(forRemoval = true)
     public SELF useMutualTls(String tlsTruststoreFilename, String tlsTruststorePassword, HttpsClientAuth httpsClientAuth) {
@@ -428,17 +428,26 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     }
 
     /**
-     * Configures the server to require/request client authentication with mTLS.
+     * Configure the Keycloak Truststore to communicate through TLS.
      *
      * @param tlsTrustedCertificateFilenames List of pkcs12 (p12 or pfx file extensions), PEM files, or directories containing those files
      *                                       that will be used as a system truststore.
+     * @return self
+     */
+    public SELF withTrustedCertificates(List<String> tlsTrustedCertificateFilenames) {
+        requireNonNull(tlsTrustedCertificateFilenames, "tlsTrustCertificateFilenames must not be null");
+        this.tlsTrustedCertificateFilenames = tlsTrustedCertificateFilenames;
+        return self();
+    }
+
+    /**
+     * Configures the server to require/request client authentication.
+     *
      * @param httpsClientAuth The http-client-auth mode
      * @return self
      */
-    public SELF withMutualTls(List<String> tlsTrustedCertificateFilenames, HttpsClientAuth httpsClientAuth) {
-        requireNonNull(tlsTrustedCertificateFilenames, "tlsTrustCertificateFilenames must not be null");
+    public SELF withHttpsClientAuth(HttpsClientAuth httpsClientAuth) {
         requireNonNull(httpsClientAuth, "httpsClientAuth must not be null");
-        this.tlsTrustedCertificateFilenames = tlsTrustedCertificateFilenames;
         this.httpsClientAuth = httpsClientAuth;
         this.useTls = true;
         return self();

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsLegacyTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsLegacyTest.java
@@ -1,0 +1,105 @@
+package dasniko.testcontainers.keycloak;
+
+import io.restassured.RestAssured;
+import io.restassured.config.SSLConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.time.Duration;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+public class KeycloakContainerHttpsLegacyTest {
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.reset();
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequestNoMutualTls() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            keycloak.start();
+            checkTls(keycloak, "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequestWithMutualTls() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            keycloak.start();
+            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequiredWithMutualTls() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
+        ) {
+            keycloak.start();
+            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequiredWithoutMutualTls() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
+        ) {
+            keycloak.start();
+            assertThrows(SSLHandshakeException.class, () -> checkTls(keycloak, "keycloak.jks", "keycloak"));
+        }
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionUponNullTlsTruststoreFilename() {
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls(null, null, HttpsClientAuth.NONE));
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionUponNullHttpsClientAuth() {
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls("keycloak.jks", null, null));
+    }
+
+    private void checkTls(KeycloakContainer keycloak, String pathToTruststore, String truststorePassword) {
+        RestAssured.config = RestAssured.config().sslConfig(
+            SSLConfig.sslConfig().trustStore(pathToTruststore, truststorePassword)
+        );
+
+        assertThat(keycloak.getAuthServerUrl(), startsWith("https://"));
+
+        given()
+            .when().get(keycloak.getAuthServerUrl())
+            .then().statusCode(200);
+    }
+
+    private void checkMutualTls(KeycloakContainer keycloak, String pathToTruststore, String truststorePassword, String pathToKeystore,
+        String keystorePassword) {
+        RestAssured.config = RestAssured.config().sslConfig(
+            SSLConfig.sslConfig()
+                .trustStore(pathToTruststore, truststorePassword)
+                .keyStore(pathToKeystore, keystorePassword)
+        );
+
+        assertThat(keycloak.getAuthServerUrl(), startsWith("https://"));
+
+        given()
+            .when().get(keycloak.getAuthServerUrl())
+            .then().statusCode(200);
+    }
+
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
@@ -70,7 +70,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequestNoMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUEST)
+            .withTrustedCertificates(List.of("keycloak.crt"))
+            .withHttpsClientAuth(HttpsClientAuth.REQUEST)
         ) {
             keycloak.start();
             checkTls(keycloak, "keycloak.jks", "keycloak");
@@ -81,7 +82,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequestWithMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUEST)
+            .withTrustedCertificates(List.of("keycloak.crt"))
+            .withHttpsClientAuth(HttpsClientAuth.REQUEST)
         ) {
             keycloak.start();
             checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
@@ -92,7 +94,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequiredWithMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUIRED)
+            .withTrustedCertificates(List.of("keycloak.crt"))
+            .withHttpsClientAuth(HttpsClientAuth.REQUIRED)
             .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
         ) {
             keycloak.start();
@@ -104,7 +107,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequiredWithoutMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUIRED)
+            .withTrustedCertificates(List.of("keycloak.crt"))
+            .withHttpsClientAuth(HttpsClientAuth.REQUIRED)
             .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
         ) {
             keycloak.start();
@@ -114,12 +118,12 @@ public class KeycloakContainerHttpsTest {
 
     @Test
     public void shouldThrowNullPointerExceptionUponNullTlsTrustCertFilename() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withMutualTls(null, HttpsClientAuth.NONE));
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withTrustedCertificates(null));
     }
 
     @Test
     public void shouldThrowNullPointerExceptionUponNullHttpsClientAuth() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withMutualTls(List.of("keycloak.crt"), null));
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withHttpsClientAuth(null));
     }
 
     @Test

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
@@ -8,8 +8,8 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ServerInfoResource;
 
 import javax.net.ssl.SSLHandshakeException;
-
 import java.time.Duration;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -70,7 +70,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequestNoMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUEST)
+        ) {
             keycloak.start();
             checkTls(keycloak, "keycloak.jks", "keycloak");
         }
@@ -80,7 +81,8 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequestWithMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUEST)
+        ) {
             keycloak.start();
             checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
         }
@@ -90,7 +92,7 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequiredWithMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUIRED)
             .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
         ) {
             keycloak.start();
@@ -102,7 +104,7 @@ public class KeycloakContainerHttpsTest {
     public void shouldStartKeycloakWithMutualTlsRequiredWithoutMutualTls() {
         try (KeycloakContainer keycloak = new KeycloakContainer()
             .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .withMutualTls(List.of("keycloak.crt"), HttpsClientAuth.REQUIRED)
             .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
         ) {
             keycloak.start();
@@ -111,13 +113,13 @@ public class KeycloakContainerHttpsTest {
     }
 
     @Test
-    public void shouldThrowNullPointerExceptionUponNullTlsTruststoreFilename() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls(null, null, HttpsClientAuth.NONE));
+    public void shouldThrowNullPointerExceptionUponNullTlsTrustCertFilename() {
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withMutualTls(null, HttpsClientAuth.NONE));
     }
 
     @Test
     public void shouldThrowNullPointerExceptionUponNullHttpsClientAuth() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls("keycloak.jks", null, null));
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().withMutualTls(List.of("keycloak.crt"), null));
     }
 
     @Test
@@ -153,6 +155,64 @@ public class KeycloakContainerHttpsTest {
             checkAdminClient(keycloak);
         }
     }
+
+    // DEPRECATED LEGACY TESTS (for removal when #useMutualTls() method is being removed)
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequestNoMutualTls_legacy() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            keycloak.start();
+            checkTls(keycloak, "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequestWithMutualTls_legacy() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
+            keycloak.start();
+            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequiredWithMutualTls_legacy() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
+        ) {
+            keycloak.start();
+            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
+        }
+    }
+
+    @Test
+    public void shouldStartKeycloakWithMutualTlsRequiredWithoutMutualTls_legacy() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .useTlsKeystore("keycloak.jks", "keycloak")
+            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
+        ) {
+            keycloak.start();
+            assertThrows(SSLHandshakeException.class, () -> checkTls(keycloak, "keycloak.jks", "keycloak"));
+        }
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionUponNullTlsTruststoreFilename_legacy() {
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls(null, null, HttpsClientAuth.NONE));
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionUponNullHttpsClientAuth_legacy() {
+        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls("keycloak.jks", null, null));
+    }
+
+    // END DEPRECATED LEGACY TESTS
 
     private void checkTls(KeycloakContainer keycloak, String pathToTruststore, String truststorePassword) {
         RestAssured.config = RestAssured.config().sslConfig(

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerHttpsTest.java
@@ -160,64 +160,6 @@ public class KeycloakContainerHttpsTest {
         }
     }
 
-    // DEPRECATED LEGACY TESTS (for removal when #useMutualTls() method is being removed)
-
-    @Test
-    public void shouldStartKeycloakWithMutualTlsRequestNoMutualTls_legacy() {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
-            .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
-            keycloak.start();
-            checkTls(keycloak, "keycloak.jks", "keycloak");
-        }
-    }
-
-    @Test
-    public void shouldStartKeycloakWithMutualTlsRequestWithMutualTls_legacy() {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
-            .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUEST)) {
-            keycloak.start();
-            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
-        }
-    }
-
-    @Test
-    public void shouldStartKeycloakWithMutualTlsRequiredWithMutualTls_legacy() {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
-            .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
-            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
-        ) {
-            keycloak.start();
-            checkMutualTls(keycloak, "keycloak.jks", "keycloak", "keycloak.jks", "keycloak");
-        }
-    }
-
-    @Test
-    public void shouldStartKeycloakWithMutualTlsRequiredWithoutMutualTls_legacy() {
-        try (KeycloakContainer keycloak = new KeycloakContainer()
-            .useTlsKeystore("keycloak.jks", "keycloak")
-            .useMutualTls("keycloak.jks", "keycloak", HttpsClientAuth.REQUIRED)
-            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY.withStartupTimeout(Duration.ofMinutes(2))) // this is hopefully only a workaround until mgmt port does not require mutual tls
-        ) {
-            keycloak.start();
-            assertThrows(SSLHandshakeException.class, () -> checkTls(keycloak, "keycloak.jks", "keycloak"));
-        }
-    }
-
-    @Test
-    public void shouldThrowNullPointerExceptionUponNullTlsTruststoreFilename_legacy() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls(null, null, HttpsClientAuth.NONE));
-    }
-
-    @Test
-    public void shouldThrowNullPointerExceptionUponNullHttpsClientAuth_legacy() {
-        assertThrows(NullPointerException.class, () -> new KeycloakContainer().useMutualTls("keycloak.jks", null, null));
-    }
-
-    // END DEPRECATED LEGACY TESTS
-
     private void checkTls(KeycloakContainer keycloak, String pathToTruststore, String truststorePassword) {
         RestAssured.config = RestAssured.config().sslConfig(
             SSLConfig.sslConfig().trustStore(pathToTruststore, truststorePassword)


### PR DESCRIPTION
resolves #134 

Deprecating the method `.useMutualTls(String tlsTruststoreFilename, String tlsTruststorePassword, HttpsClientAuth httpsClientAuth)` and adding new methods to configure the truststore

    .withTrustedCertificates(List<String> tlsTrustedCertificateFilenames)

and a separate method to configure mTLS independently

    .withHttpsClientAuth(HttpsClientAuth httpsClientAuth)

Once the `https-trust-store-*` config options are being removed from Keycloak, also the deprecated method will be removed from this testcontainer.