### PR TITLE
Add support for production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ KeycloakContainer keycloak = new KeycloakContainer()
 
 A warning will be printed to the log output when custom command parts are being used, so that you are aware that you are responsible on your own for proper execution of this container.
 
+## Starting in production mode
+
+By default, the container is started in dev mode (`start-dev`).
+If needed you can enable production mode: 
+
+```java
+@Container
+KeycloakContainer keycloak = new KeycloakContainer()
+    .withProductionMode();
+```
+
 ## Testing Custom Extensions
 
 To ease extension testing, you can tell the Keycloak Testcontainer to detect extensions in a given classpath folder.

--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -73,6 +73,8 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     private static final int DEFAULT_INITIAL_RAM_PERCENTAGE = 1;
     private static final int DEFAULT_MAX_RAM_PERCENTAGE = 5;
 
+    private static final String KEYCLOAK_START_DEV_COMMAND = "start-dev";
+    private static final String KEYCLOAK_START_PRODUCTION_COMMAND = "start";
     private static final String KEYCLOAK_ADMIN_USER = "admin";
     private static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
     private static final String KEYCLOAK_CONTEXT_PATH = "";
@@ -86,6 +88,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     private static final String KEYSTORE_FILE_IN_CONTAINER = KEYCLOAK_CONF_DIR + "/server.keystore";
     private static final String TRUSTSTORE_FILE_IN_CONTAINER = KEYCLOAK_CONF_DIR + "/server.truststore";
 
+    private String startupCommand = KEYCLOAK_START_DEV_COMMAND;
     private String adminUsername = KEYCLOAK_ADMIN_USER;
     private String adminPassword = KEYCLOAK_ADMIN_PASSWORD;
     private String contextPath = KEYCLOAK_CONTEXT_PATH;
@@ -144,7 +147,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
         if (useVerbose) {
             commandParts.add("--verbose");
         }
-        commandParts.add("start-dev");
+        commandParts.add(startupCommand);
 
         if (!contextPath.equals(KEYCLOAK_CONTEXT_PATH)) {
             withEnv("KC_HTTP_RELATIVE_PATH", contextPath);
@@ -331,6 +334,11 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
             .getParent()
             .resolve(extensionClassFolder)
             .toString();
+    }
+
+    public SELF withProductionMode() {
+        this.startupCommand = KEYCLOAK_START_PRODUCTION_COMMAND;
+        return self();
     }
 
     public SELF withRealmImportFile(String importFile) {


### PR DESCRIPTION
Hi there, 

For test purpose, I need to start the container in production mode, but the `start-dev` is hardcoded.

Let me propose you this PR to easily start the container in production mode.

I've also added a method `postProcessCommandParts` on a separate commit to easily extend this: 

```
        final KeycloakContainer keycloak = new KeycloakContainer(IMAGE_NAME) {

            protected List<String> postProcessCommandParts(final List<String> commandParts) {
                return commandParts.stream()
                        // do fancy stuff here
                        .toList();
            }

        };

```

I managed to make it by extending the container but I think this could be simpler with this PR: 

```
        final KeycloakContainer keycloak = new KeycloakContainer(IMAGE_NAME) {
            
            @Override
            protected void configure() {
                super.configure();

                String[] adapted = Arrays.stream(this.getCommandParts())
                        .map(part -> {
                            if (part.equals("start-dev")) {
                                return "start";
                            } else {
                                return part;
                            }
                        }).toList().toArray(new String[0]);
                setCommand(adapted);

            }
        }
```
