### PR TITLE
chore(deps): bump testcontainers from 1.21.3 to 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,24 +352,6 @@ Simply put the dependency coordinates to your `pom.xml` (or something similar, i
 
 > There is also a `999.0.0-SNAPSHOT` version available, pointing to `nightly` Docker image by default and using the `999.0.0-SNAPSHOT` Keycloak libraries as dependencies.
 
-### JUnit4 Dependency
-
-The testcontainers project itself has a dependency on JUnit4 although it is not needed for this project in order to run (see this [issue](https://github.com/testcontainers/testcontainers-java/issues/970) for more details).
-To avoid pulling in JUnit4 this project comes with a dependency on the `quarkus-junit4-mock` library which includes all needed classes as empty stubs. If you need JUnit4 in your project you should exclude this mock library
-when declaring the dependency to `testcontainers-keycloak` to avoid issues. Example for maven:
-
-```xml
-<dependency>
-    <!-- ... see above -->
-    <exclusions>
-        <exclusion>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit4-mock</artifactId>
-        </exclusion>
-    </exclusions>
-</dependency>
-```
-
 ## Usage in your application framework tests
 
 > This info is not specific to the Keycloak Testcontainer, but using Testcontainers in general.

--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,11 @@
         <logback.version>1.5.21</logback.version>
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.version>3.28.1</quarkus.version>
         <rest-assured.version>5.5.6</rest-assured.version>
         <shrinkwrap.version>2.0.0-beta-2</shrinkwrap.version>
         <shrinkwrap-resolver.version>3.3.4</shrinkwrap-resolver.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>2.0.2</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -85,23 +84,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-        <!--
-        Module with some empty JUnit4 classes to allow Testcontainers to run without needing to include JUnit4 on the class path
-        See also https://github.com/testcontainers/testcontainers-java/issues/970 for more details
-        -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit4-mock</artifactId>
-            <version>${quarkus.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>


### PR DESCRIPTION
Testcontainers v2 was released in October 2025

https://github.com/testcontainers/testcontainers-java/releases
