### PR TITLE
fix: Wait for log output "Listening..." to wait until optional imports are done

### DIFF
--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -74,7 +74,7 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     private static final int KEYCLOAK_PORT_DEBUG = 8787;
     private static final int KEYCLOAK_PORT_MGMT = 9000;
 
-    public static final WaitStrategy LOG_WAIT_STRATEGY = Wait.forLogMessage("Listening on\\: http:\\/\\/0\\.0\\.0\\.0:" + KEYCLOAK_PORT_HTTP + "\\. Management interface listening on http\\:\\/\\/0\\.0\\.0\\.0:" + KEYCLOAK_PORT_MGMT +"*\\..*", 1);
+    public static final WaitStrategy LOG_WAIT_STRATEGY = Wait.forLogMessage(".*Listening on\\: http:\\/\\/0\\.0\\.0\\.0:" + KEYCLOAK_PORT_HTTP + "\\. Management interface listening on http\\:\\/\\/0\\.0\\.0\\.0:" + KEYCLOAK_PORT_MGMT +"\\..*", 1);
 
     private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(2);
     private static final int DEFAULT_INITIAL_RAM_PERCENTAGE = 1;

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerTest.java
@@ -208,6 +208,15 @@ public class KeycloakContainerTest {
         }
     }
 
+    @Test
+    public void shouldStartKeycloakWithDifferentWaitStrategy() {
+        try (KeycloakContainer keycloak = new KeycloakContainer()
+            .waitingFor(KeycloakContainer.LOG_WAIT_STRATEGY)) {
+            keycloak.start();
+            checkKeycloakContainerInternals(keycloak);
+        }
+    }
+
     private static ValidatableResponse getWellKnownOpenidConfigurationResponse(String authServerUrl) {
         return given().when().get(authServerUrl + "/realms/master/.well-known/openid-configuration")
             .then().statusCode(200);


### PR DESCRIPTION
Hi @dasniko ,

thanks a lot for your great work on this testcontainers module! It is really helpful.

I am using the method `.withRealmImportFile("...")` to import a preconfigured realm on container startup, that takes up to 30s.
The tests are failing sometimes because keycloak is not ready to accept connections.

The log messages "...Listening on ..." are logged when keycloak imported the realms.