### PR TITLE
add OIDC endpoint URL helpers and SimpleHttp utility

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -19,7 +19,7 @@ jobs:
           - shard: 3
             classes: "dasniko.testcontainers.keycloak.KeycloakContainerHttpsLegacyTest,dasniko.testcontainers.keycloak.KeycloakContainerOptimizedTest"
           - shard: 4
-            classes: "dasniko.testcontainers.keycloak.KeycloakContainerExtensionTest,dasniko.testcontainers.keycloak.KeycloakContainerExtensionReuseTest"
+            classes: "dasniko.testcontainers.keycloak.KeycloakContainerExtensionTest,dasniko.testcontainers.keycloak.KeycloakContainerExtensionReuseTest,dasniko.testcontainers.keycloak.KeycloakContainerEndpointHelpersTest"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
           - shard: 3
             classes: "dasniko.testcontainers.keycloak.KeycloakContainerHttpsLegacyTest,dasniko.testcontainers.keycloak.KeycloakContainerOptimizedTest"
           - shard: 4
-            classes: "dasniko.testcontainers.keycloak.KeycloakContainerExtensionTest,dasniko.testcontainers.keycloak.KeycloakContainerExtensionReuseTest"
+            classes: "dasniko.testcontainers.keycloak.KeycloakContainerExtensionTest,dasniko.testcontainers.keycloak.KeycloakContainerExtensionReuseTest,dasniko.testcontainers.keycloak.KeycloakContainerEndpointHelpersTest"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ testImplementation("com.github.dasniko:testcontainers-keycloak:VERSION")
   - [Initial admin user credentials](#initial-admin-user-credentials)
   - [Realm Import](#realm-import)
   - [Getting an admin client and other information](#getting-an-admin-client-and-other-information-from-the-testcontainer)
+  - [OIDC Endpoint URL Helpers](#oidc-endpoint-url-helpers)
   - [Context Path](#context-path)
   - [Management Port](#management-port)
   - [Memory Settings](#memory-settings)
@@ -178,6 +179,30 @@ Keycloak keycloakAdminClient = KeycloakBuilder.builder()
     .username(keycloak.getAdminUsername())
     .password(keycloak.getAdminPassword())
     .build();
+```
+
+### OIDC Endpoint URL Helpers
+
+Instead of manually concatenating URLs, you can use the built-in helpers to retrieve the standard OIDC endpoint URLs for a given realm directly from the container:
+
+```java
+String openIdConfigUrl = keycloak.getOpenIdConfigurationUrl("my-realm");
+String issuerUrl       = keycloak.getIssuerUrl("my-realm");
+String tokenEndpoint   = keycloak.getTokenEndpoint("my-realm");
+String jwksUri         = keycloak.getJwksUri("my-realm");
+String userInfoUrl     = keycloak.getUserInfoEndpoint("my-realm");
+```
+
+The values are fetched from the OpenID Connect discovery document (`/.well-known/openid-configuration`) and cached per realm, so repeated calls do not result in additional HTTP requests.
+
+This is particularly handy when configuring your application under test, for example with Spring Boot's `@DynamicPropertySource`:
+
+```java
+@DynamicPropertySource
+static void keycloakProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
+        () -> keycloak.getIssuerUrl("my-realm"));
+}
 ```
 
 ### Context Path
@@ -414,7 +439,7 @@ class MyTest {
     @DynamicPropertySource
     static void keycloakProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
-            () -> keycloak.getAuthServerUrl() + "/realms/test");
+            () -> keycloak.getIssuerUrl("test"));
     }
 }
 ```
@@ -436,7 +461,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         keycloak.start();
         return Map.of(
-            "quarkus.oidc.auth-server-url", keycloak.getAuthServerUrl() + "/realms/test",
+            "quarkus.oidc.auth-server-url", keycloak.getIssuerUrl("test"),
             "quarkus.oidc.client-id", "my-client"
         );
     }

--- a/docs/quarkus.md
+++ b/docs/quarkus.md
@@ -49,8 +49,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         keycloak.start();
         return Map.of(
-            "quarkus.oidc.auth-server-url",
-                keycloak.getAuthServerUrl() + "/realms/test",
+            "quarkus.oidc.auth-server-url", keycloak.getIssuerUrl("test"),
             "quarkus.oidc.client-id", "my-client",
             "quarkus.oidc.credentials.secret", "my-secret"
         );
@@ -118,8 +117,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         keycloak.start();
         return Map.of(
-            "quarkus.oidc.auth-server-url",
-                keycloak.getAuthServerUrl() + "/realms/test"
+            "quarkus.oidc.auth-server-url", keycloak.getIssuerUrl("test")
         );
     }
 
@@ -157,8 +155,7 @@ public class KeycloakTestResource implements QuarkusTestResourceLifecycleManager
     public Map<String, String> start() {
         keycloak.start();
         return Map.of(
-            "quarkus.oidc.auth-server-url",
-                keycloak.getAuthServerUrl() + "/realms/test"
+            "quarkus.oidc.auth-server-url", keycloak.getIssuerUrl("test")
         );
     }
 
@@ -240,8 +237,7 @@ import java.nio.charset.StandardCharsets;
 
 private String obtainClientCredentialsToken(String realm, String clientId,
                                              String clientSecret) throws Exception {
-    String tokenUrl = keycloak.getAuthServerUrl()
-        + "/realms/" + realm + "/protocol/openid-connect/token";
+    String tokenUrl = keycloak.getTokenEndpoint(realm);
     String body = "grant_type=client_credentials"
         + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
         + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
@@ -269,13 +265,12 @@ When your Quarkus application uses multiple OIDC tenants (`quarkus.oidc.tenants.
 @Override
 public Map<String, String> start() {
     keycloak.start();
-    String base = keycloak.getAuthServerUrl();
     return Map.of(
         // Default tenant
-        "quarkus.oidc.auth-server-url",       base + "/realms/default",
+        "quarkus.oidc.auth-server-url",       keycloak.getIssuerUrl("default"),
         "quarkus.oidc.client-id",             "default-client",
         // Named tenant
-        "quarkus.oidc.tenants.partner.auth-server-url",  base + "/realms/partner",
+        "quarkus.oidc.tenants.partner.auth-server-url",  keycloak.getIssuerUrl("partner"),
         "quarkus.oidc.tenants.partner.client-id",        "partner-client"
     );
 }
@@ -289,12 +284,11 @@ For applications using `quarkus-oidc-client` to call downstream services:
 @Override
 public Map<String, String> start() {
     keycloak.start();
-    String base = keycloak.getAuthServerUrl() + "/realms/test";
     return Map.of(
         // Resource server side
-        "quarkus.oidc.auth-server-url",                        base,
+        "quarkus.oidc.auth-server-url",                        keycloak.getIssuerUrl("test"),
         // OIDC client side (outgoing token requests)
-        "quarkus.oidc-client.auth-server-url",                 base,
+        "quarkus.oidc-client.auth-server-url",                 keycloak.getIssuerUrl("test"),
         "quarkus.oidc-client.client-id",                       "service-client",
         "quarkus.oidc-client.credentials.secret",              "service-secret",
         "quarkus.oidc-client.grant.type",                      "client"
@@ -315,10 +309,9 @@ private static final KeycloakContainer keycloak =
 @Override
 public Map<String, String> start() {
     keycloak.start();
-    // getAuthServerUrl() returns HTTPS when TLS is enabled
+    // getIssuerUrl() returns an HTTPS URL when TLS is enabled
     return Map.of(
-        "quarkus.oidc.auth-server-url",
-            keycloak.getAuthServerUrl() + "/realms/test",
+        "quarkus.oidc.auth-server-url", keycloak.getIssuerUrl("test"),
         "quarkus.tls.trust-all", "true"   // only for tests — never in production
     );
 }

--- a/docs/spring-boot.md
+++ b/docs/spring-boot.md
@@ -79,7 +79,7 @@ class ResourceServerIntegrationTest {
     @DynamicPropertySource
     static void keycloakProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
-            () -> keycloak.getAuthServerUrl() + "/realms/test");
+            () -> keycloak.getIssuerUrl("test"));
     }
 
     @Autowired
@@ -122,7 +122,7 @@ For applications acting as an OAuth2 client (e.g., calling a downstream API with
 ```java
 @DynamicPropertySource
 static void keycloakProperties(DynamicPropertyRegistry registry) {
-    String issuerUri = keycloak.getAuthServerUrl() + "/realms/test";
+    String issuerUri = keycloak.getIssuerUrl("test");
     registry.add("spring.security.oauth2.client.provider.keycloak.issuer-uri", () -> issuerUri);
     registry.add("spring.security.oauth2.client.registration.keycloak.client-id", () -> "my-client");
     registry.add("spring.security.oauth2.client.registration.keycloak.client-secret", () -> "my-secret");
@@ -160,7 +160,7 @@ class ResourceServerTest {
         public void initialize(ConfigurableApplicationContext ctx) {
             TestPropertyValues.of(
                 "spring.security.oauth2.resourceserver.jwt.issuer-uri=" +
-                    keycloak.getAuthServerUrl() + "/realms/test"
+                    keycloak.getIssuerUrl("test")
             ).applyTo(ctx.getEnvironment());
         }
     }
@@ -190,7 +190,7 @@ abstract class AbstractKeycloakIntegrationTest {
     @DynamicPropertySource
     static void keycloakProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
-            () -> keycloak.getAuthServerUrl() + "/realms/test");
+            () -> keycloak.getIssuerUrl("test"));
     }
 }
 ```
@@ -241,8 +241,7 @@ import java.nio.charset.StandardCharsets;
 
 private String obtainAccessToken(String realm, String clientId, String clientSecret)
         throws Exception {
-    String tokenUrl = keycloak.getAuthServerUrl()
-        + "/realms/" + realm + "/protocol/openid-connect/token";
+    String tokenUrl = keycloak.getTokenEndpoint(realm);
     String body = "grant_type=client_credentials"
         + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
         + "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
@@ -276,9 +275,9 @@ static KeycloakContainer keycloak = new KeycloakContainer("quay.io/keycloak/keyc
 
 @DynamicPropertySource
 static void keycloakProperties(DynamicPropertyRegistry registry) {
-    // getAuthServerUrl() returns an HTTPS URL when TLS is enabled
+    // getIssuerUrl() returns an HTTPS URL when TLS is enabled
     registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
-        () -> keycloak.getAuthServerUrl() + "/realms/test");
+        () -> keycloak.getIssuerUrl("test"));
 
     // Trust the built-in self-signed certificate
     registry.add("spring.ssl.bundle.jks.keycloak.truststore.location",

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <logback.version>1.5.32</logback.version>
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <lombok.version>1.18.44</lombok.version>
         <rest-assured.version>6.0.0</rest-assured.version>
         <shrinkwrap.version>2.0.0-beta-2</shrinkwrap.version>
         <shrinkwrap-resolver.version>3.3.5</shrinkwrap-resolver.version>
@@ -105,6 +106,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/ExtendableKeycloakContainer.java
@@ -55,7 +55,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 
@@ -134,6 +137,8 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
 
     private boolean bootstrapAdmin = true;
     private boolean optimizeFlag = false;
+
+    private final Map<String, String> openIdConfigCache = new ConcurrentHashMap<>();
 
     /**
      * Create a KeycloakContainer with the default image and version tag
@@ -679,6 +684,49 @@ public abstract class ExtendableKeycloakContainer<SELF extends ExtendableKeycloa
     public String getKeycloakDefaultVersion() {
         RemoteDockerImage image = this.getImage();
         return this.getDockerImageName().endsWith(":nightly") ? "999.0.0-SNAPSHOT" : KEYCLOAK_VERSION;
+    }
+
+    public String getOpenIdConfigurationUrl(String realmName) {
+        return String.format("%s/realms/%s/.well-known/openid-configuration", getAuthServerUrl(), realmName);
+    }
+
+    public String getIssuerUrl(String realmName) {
+        return getOpenIdConfigValue(realmName, "issuer");
+    }
+
+    public String getTokenEndpoint(String realmName) {
+        return getOpenIdConfigValue(realmName, "token_endpoint");
+    }
+
+    public String getJwksUri(String realmName) {
+        return getOpenIdConfigValue(realmName, "jwks_uri");
+    }
+
+    public String getUserInfoEndpoint(String realmName) {
+        return getOpenIdConfigValue(realmName, "userinfo_endpoint");
+    }
+
+    private String getOpenIdConfigValue(String realmName, String fieldName) {
+        String openIdConfigUrl = getOpenIdConfigurationUrl(realmName);
+        String body = openIdConfigCache.computeIfAbsent(realmName, k -> {
+            try {
+                SimpleHttp simpleHttp = SimpleHttp.doGet(openIdConfigUrl);
+                if (useTls) {
+                    SSLContext sslContext = buildSslContext();
+                    if (sslContext != null) {
+                        simpleHttp.sslContext(sslContext);
+                    }
+                }
+                return simpleHttp.asResponse().getBody();
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to fetch OpenID configuration from " + openIdConfigUrl, e);
+            }
+        });
+        Matcher matcher = Pattern.compile("\"" + fieldName + "\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        throw new IllegalStateException("No '" + fieldName + "' field found in OpenID configuration response from " + openIdConfigUrl);
     }
 
     private boolean isNotBlank(String s) {

--- a/src/main/java/dasniko/testcontainers/keycloak/SimpleHttp.java
+++ b/src/main/java/dasniko/testcontainers/keycloak/SimpleHttp.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Niko Köbler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dasniko.testcontainers.keycloak;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Minimal HTTP client helper, modelled after Keycloak's {@code org.keycloak.http.simple.SimpleHttp}.
+ * Uses only {@link java.net.http.HttpClient} — no additional dependencies.
+ */
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+class SimpleHttp {
+
+    private final String method;
+    private final String url;
+    private SSLContext sslContext;
+
+    static SimpleHttp doGet(String url) {
+        return new SimpleHttp("GET", url);
+    }
+
+    SimpleHttp sslContext(SSLContext sslContext) {
+        this.sslContext = sslContext;
+        return this;
+    }
+
+    Response asResponse() throws IOException {
+        HttpClient.Builder clientBuilder = HttpClient.newBuilder();
+        if (sslContext != null) {
+            clientBuilder.sslContext(sslContext);
+        }
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .method(method, HttpRequest.BodyPublishers.noBody())
+            .build();
+        try {
+            HttpResponse<String> response = clientBuilder.build().send(request, HttpResponse.BodyHandlers.ofString());
+            return new Response(response.statusCode(), response.body());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("HTTP request was interrupted", e);
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    static class Response {
+        private final int status;
+        private final String body;
+    }
+}

--- a/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerEndpointHelpersTest.java
+++ b/src/test/java/dasniko/testcontainers/keycloak/KeycloakContainerEndpointHelpersTest.java
@@ -1,0 +1,74 @@
+package dasniko.testcontainers.keycloak;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static dasniko.testcontainers.keycloak.KeycloakContainerTest.KC_IMAGE;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * @author Niko Köbler, https://www.n-k.de, @dasniko
+ */
+public class KeycloakContainerEndpointHelpersTest {
+
+    static final KeycloakContainer KEYCLOAK = new KeycloakContainer(KC_IMAGE);
+
+    @BeforeAll
+    static void startKeycloak() {
+        KEYCLOAK.start();
+    }
+
+    @AfterAll
+    static void stopKeycloak() {
+        KEYCLOAK.stop();
+    }
+
+    @Test
+    void shouldReturnOpenIdConfigurationUrl() {
+        String url = KEYCLOAK.getOpenIdConfigurationUrl("master");
+        assertThat(url, startsWith(KEYCLOAK.getAuthServerUrl()));
+        assertThat(url, endsWith("/realms/master/.well-known/openid-configuration"));
+        given().when().get(url).then().statusCode(200);
+    }
+
+    @Test
+    void shouldReturnIssuerUrl() {
+        String issuerUrl = KEYCLOAK.getIssuerUrl("master");
+        assertThat(issuerUrl, equalTo(KEYCLOAK.getAuthServerUrl() + "/realms/master"));
+    }
+
+    @Test
+    void shouldReturnTokenEndpoint() {
+        String tokenEndpoint = KEYCLOAK.getTokenEndpoint("master");
+        assertThat(tokenEndpoint, startsWith(KEYCLOAK.getAuthServerUrl()));
+        assertThat(tokenEndpoint, endsWith("/realms/master/protocol/openid-connect/token"));
+    }
+
+    @Test
+    void shouldReturnJwksUri() {
+        String jwksUri = KEYCLOAK.getJwksUri("master");
+        assertThat(jwksUri, startsWith(KEYCLOAK.getAuthServerUrl()));
+        assertThat(jwksUri, endsWith("/realms/master/protocol/openid-connect/certs"));
+        given().when().get(jwksUri).then().statusCode(200);
+    }
+
+    @Test
+    void shouldReturnUserInfoEndpoint() {
+        String userInfoEndpoint = KEYCLOAK.getUserInfoEndpoint("master");
+        assertThat(userInfoEndpoint, startsWith(KEYCLOAK.getAuthServerUrl()));
+        assertThat(userInfoEndpoint, endsWith("/realms/master/protocol/openid-connect/userinfo"));
+    }
+
+    @Test
+    void shouldReturnConsistentValuesOnRepeatedCalls() {
+        assertThat(KEYCLOAK.getIssuerUrl("master"), equalTo(KEYCLOAK.getIssuerUrl("master")));
+        assertThat(KEYCLOAK.getTokenEndpoint("master"), equalTo(KEYCLOAK.getTokenEndpoint("master")));
+        assertThat(KEYCLOAK.getJwksUri("master"), equalTo(KEYCLOAK.getJwksUri("master")));
+        assertThat(KEYCLOAK.getUserInfoEndpoint("master"), equalTo(KEYCLOAK.getUserInfoEndpoint("master")));
+    }
+}


### PR DESCRIPTION
## Description

Add getOpenIdConfigurationUrl(), getIssuerUrl(), getTokenEndpoint(), getJwksUri() and getUserInfoEndpoint() methods to avoid manual URL concatenation. Introduce internal SimpleHttp helper for HTTP requests. OpenID configuration responses are cached per realm (ConcurrentHashMap) to avoid redundant network calls. Lombok added for boilerplate reduction.

## Related issue

Closes #285

## Checklist

- [x] `./mvnw clean verify` passes locally
- [x] Tests cover the changed behaviour
- [x] README updated (if user-facing change)
